### PR TITLE
Adding a theme toggle to the Home page (Dark Mode/Light Mode)  Issue  #119

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -2451,3 +2451,64 @@ body {
         padding: 8px;
     }
 }
+
+
+
+
+
+/*
+
+toggle button...........................
+
+*/
+
+
+#theme-toggle {
+    padding: 8px 15px;
+    border: none;
+    cursor: pointer;
+    background-color: #333;
+    color: white;
+    font-size: 14px;
+    border-radius: 5px;
+    transition: background-color 0.3s ease-in-out;
+}
+
+#theme-toggle:hover {
+    background-color: #555;
+}
+
+
+.auth-buttons {
+    display: flex;
+    gap: 10px; 
+    align-items: center;
+}
+
+/* Dark Mode Styling */
+.dark-mode {
+    background-color: black;
+    color: white;
+}
+
+.dark-mode .navbar {
+    background-color: black; 
+    opacity:1;
+}
+
+.dark-mode .nav-menu a {
+    color: white;
+}
+
+.dark-mode .login-btn {
+    background-color: #444;
+}
+
+.dark-mode #theme-toggle {
+    background-color: white;
+    color: black;
+}
+
+.dark-mode #theme-toggle:hover {
+    background-color: lightgray;
+}

--- a/JS/script.js
+++ b/JS/script.js
@@ -503,3 +503,33 @@ tabButtons.forEach(button => {
         displayBlogs(button.getAttribute("data-category"));
     });
 });
+
+
+
+
+
+
+
+
+
+
+document.addEventListener("DOMContentLoaded", function () {
+    const toggleButton = document.getElementById("theme-toggle");
+    const body = document.body;
+
+
+    if (localStorage.getItem("theme") === "dark") {
+        body.classList.add("dark-mode");
+    }
+
+    toggleButton.addEventListener("click", function () {
+        body.classList.toggle("dark-mode");
+
+        
+        if (body.classList.contains("dark-mode")) {
+            localStorage.setItem("theme", "dark");
+        } else {
+            localStorage.setItem("theme", "light");
+        }
+    });
+});

--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">   
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap" rel="stylesheet"> 
     <script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script><script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script>
+    
     <link rel="stylesheet" href="../CSS/style.css">
+
 </head>
 <body>
 
@@ -66,6 +68,9 @@
                 </div>
                 <div class="auth-buttons">
                     <button class="login-btn" onclick="window.location.href='login.html'">Log In</button>
+
+                    <button id="theme-toggle">Dark Mode</button>
+
                 </div>
             </div>
         </div>
@@ -756,5 +761,6 @@
 </div>
 
 <script src="../JS/script.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
# 🔀 Pull Request  

## 📌 Issue Reference  

Closes #119 


## 📝 Description  
 As mentioned in the ISSUE no-  #119 
I have Implemented a theme toggle button in the navigation bar next to the login button. Now users can switch between light and dark modes, enhancing the visual appeal and user experience of the home page.

The selected theme is saved locally, so users don’t have to toggle it again when they revisit the site.

## 📷 Screenshots (if applicable)  
![Screenshot (193)](https://github.com/user-attachments/assets/d9be46fe-6457-4197-ba8b-68a88a7312c0)
![Screenshot (194)](https://github.com/user-attachments/assets/fd8a38db-919f-44f1-971b-8ef3dec89d7b)


## ✅ Checklist  
My code follows the project's coding style.  (YES)
I have tested my changes thoroughly.  (YES)
Necessary documentation updates have been made.  (YES)

## 🏆 Are you contributing under an open-source program?  

YES, APERTRE 2.0 

<<<<<<< HEAD
# 🏆Are you contributing under any open-source program ?

YES, APERTRE 2.0 

=======
## 💡 Additional Context (if any)  
This feature enhances user accessibility by allowing them to control the theme, improving both aesthetics and usability. 

Let me know if any modifications are needed! Looking forward to your review. @Nayanika1402 



>>>>>>> 52bf356c8d9a37fd3539c380255260d4147467bd
