### PR TITLE
Favicon added at loading page

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
               </clipPath>
             </defs>
             <image 
-              href="./favicon/favicon-192x192.png" 
+              href="./favicon/favicon_192x192.png" 
               x="5" 
               y="5" 
               width="90" 


### PR DESCRIPTION
# 🔀 Pull Request

## 📝 Summary  

- What issue does this fix?
Added favicon in loading page

---

## 📸 Screenshots (if applicable)  
<img width="1173" height="704" alt="Screenshot 2025-08-19 at 8 09 45 PM" src="https://github.com/user-attachments/assets/4cda1306-bd2a-4dab-9294-390a9c57570e" />


---

## ✅ Checklist  
- [ ✅ ] My code follows the project's coding conventions  
- [ ✅ ] I have tested all impacted features  
- [ ✅ ] I have updated or added necessary documentation  

---

## 🏅 Open Source Program Participation  

Program Name: OSCI (Open Source Connect India)

---

