### PR TITLE
Replaced WebKit-only CSS with standard properties

### DIFF
--- a/CSS/about.css
+++ b/CSS/about.css
@@ -516,8 +516,8 @@ ul {
 
 .hero-content h1 span {
   background: linear-gradient(135deg, #0073e6, #00b894);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
 }
 
 .hero-content p {

--- a/CSS/navbar.css
+++ b/CSS/navbar.css
@@ -53,7 +53,7 @@ body {
 
 .navbar {
   background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 4px 10px rgb(0, 255, 255);
   padding: 8px 20px;
   position: fixed;
   top: 0;


### PR DESCRIPTION
Replaced WebKit-only properties with their unprefixed, standard versions in about.css and changed the box-shadow to rgb (0,255,255) in navbar.css

# 🔀 Pull Request

## 📌 Issue Reference  
<!-- Link to the issue this PR addresses. PRs without an issue reference may not be merged. -->
Closes #<issue_number>  
<!-- Example: Closes #244 -->

---

### 📝 Summary
- Fixed CSS compatibility issues by replacing WebKit-only properties with unprefixed, standard versions in `about.css`.  
- Updated `box-shadow` color to use `rgb(0,255,255)` for better UX in `navbar.css`.  
---

## 📸 Screenshots (if applicable)  
<!-- Include relevant screenshots or screen recordings to demonstrate your changes. -->
<img width="923" height="581" alt="image" src="https://github.com/user-attachments/assets/6d8cb270-2d72-4697-bc95-7a4dcc773d6c" />

---

## ✅ Checklist  
- [✅] My code follows the project's coding conventions  
- [ ✅] I have tested all impacted features  
- [ ✅] I have updated or added necessary documentation  

---

## 🔗 Related Issues / PRs  
<!-- List any related issues or PRs for context. -->

---

## 🏅 Open Source Program Participation  
<!-- If contributing under an open-source program, mention it here. -->
Program Name: <!-- Example: GSoC, Hacktoberfest -->

---

## 💬 Additional Notes  
<!-- Add any other relevant information or context. -->
